### PR TITLE
Add fibonacci with a lazy sequence in Clojure

### DIFF
--- a/Clojure/fibonacci.clj
+++ b/Clojure/fibonacci.clj
@@ -1,0 +1,3 @@
+;; I like this approach because it shows the simplicity of clojure
+
+(def fib (lazy-cat [0 1] (map + fib (rest fib))))


### PR DESCRIPTION
The example is taken from http://squirrel.pl/blog/2010/07/26/corecursion-in-clojure/ and shows how to write the Fibonacci sequence in a lazy, head-first sequence.